### PR TITLE
Add compositor, Vulkan & OpenGL texture uploads, vsync time, VREvent fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,14 @@ rust-version = "1.65" # GAT and if-else
 default = [
     "ovr_applications",
     "ovr_chaperone_setup",
+    "ovr_compositor",
     "ovr_input",
     "ovr_settings",
     "ovr_system",
 ]
 ovr_applications = []
 ovr_chaperone_setup = []
+ovr_compositor = []
 ovr_input = []
 ovr_system = []
 ovr_settings = []

--- a/src/applications.rs
+++ b/src/applications.rs
@@ -77,4 +77,20 @@ impl<'c> ApplicationsManager<'c> {
 
         Ok(installed)
     }
+
+    pub fn set_application_auto_launch(&mut self, key: &str, auto_launch: bool) -> Result<()> {
+        let key_raw = if let Ok(s) = CString::new(key) {
+            s
+        } else {
+            return EVRApplicationError::new(
+                sys::EVRApplicationError::VRApplicationError_InvalidParameter,
+            );
+        };
+        let err = unsafe {
+            self.inner
+                .as_mut()
+                .SetApplicationAutoLaunch(key_raw.as_ptr(), auto_launch)
+        };
+        EVRApplicationError::new(err)
+    }
 }

--- a/src/chaperone_setup.rs
+++ b/src/chaperone_setup.rs
@@ -88,6 +88,28 @@ impl<'c> ChaperoneSetupManager<'c> {
         }
     }
 
+    pub fn get_live_collision_bounds_info(&mut self) -> Vec<HmdQuad_t> {
+        let mut num_quads = 0u32;
+        let success = unsafe {
+            self.inner
+                .as_mut()
+                .GetLiveCollisionBoundsInfo(ptr::null_mut(), &mut num_quads)
+        };
+        if !success {
+            return vec![];
+        }
+        let mut quads: Vec<HmdQuad_t> = Vec::with_capacity(num_quads as usize);
+        let success = unsafe {
+            self.inner
+                .as_mut()
+                .GetLiveCollisionBoundsInfo(quads.as_mut_ptr(), &mut num_quads)
+        };
+        if !success {
+            return vec![];
+        }
+        quads
+    }
+
     pub fn get_working_collision_bounds_info(&mut self) -> Vec<HmdQuad_t> {
         let mut num_quads = 0u32;
         let success = unsafe {
@@ -118,11 +140,56 @@ impl<'c> ChaperoneSetupManager<'c> {
         }
     }
 
+    pub fn get_working_play_area_size(&mut self) -> Option<(f32, f32)> {
+        let mut size_x = MaybeUninit::uninit();
+        let mut size_y = MaybeUninit::uninit();
+        let success = unsafe {
+            self.inner
+                .as_mut()
+                .GetWorkingPlayAreaSize(size_x.as_mut_ptr(), size_y.as_mut_ptr())
+        };
+        if success {
+            Some(unsafe { (size_x.assume_init(), size_y.assume_init()) })
+        } else {
+            None
+        }
+    }
+
+    pub fn set_working_play_area_size(&mut self, size_x: f32, size_y: f32) {
+        unsafe { self.inner.as_mut().SetWorkingPlayAreaSize(size_x, size_y) }
+    }
+
+    pub fn get_working_play_area_rect(&mut self) -> Option<HmdQuad_t> {
+        let mut rect = MaybeUninit::uninit();
+        let success = unsafe {
+            self.inner
+                .as_mut()
+                .GetWorkingPlayAreaRect(rect.as_mut_ptr())
+        };
+        if success {
+            Some(unsafe { rect.assume_init() })
+        } else {
+            None
+        }
+    }
+
     pub fn commit_working_copy(&mut self, config: sys::EChaperoneConfigFile) -> bool {
         unsafe { self.inner.as_mut().CommitWorkingCopy(config) }
     }
 
     pub fn revert_working_copy(&mut self) {
         unsafe { self.inner.as_mut().RevertWorkingCopy() }
+    }
+
+    pub fn reload_from_disk(&mut self, config: sys::EChaperoneConfigFile) {
+        unsafe { self.inner.as_mut().ReloadFromDisk(config) }
+    }
+
+    pub fn show_working_set_preview(&mut self) {
+        unsafe { self.inner.as_mut().ShowWorkingSetPreview() }
+    }
+
+    pub fn hide_working_set_preview(&mut self) {
+        unsafe { self.inner.as_mut().HideWorkingSetPreview() }
     }
 }

--- a/src/chaperone_setup.rs
+++ b/src/chaperone_setup.rs
@@ -90,12 +90,12 @@ impl<'c> ChaperoneSetupManager<'c> {
 
     pub fn get_live_collision_bounds_info(&mut self) -> Vec<HmdQuad_t> {
         let mut num_quads = 0u32;
-        let success = unsafe {
+        unsafe {
             self.inner
                 .as_mut()
                 .GetLiveCollisionBoundsInfo(ptr::null_mut(), &mut num_quads)
         };
-        if !success {
+        if num_quads == 0 {
             return vec![];
         }
         let mut quads: Vec<HmdQuad_t> = Vec::with_capacity(num_quads as usize);
@@ -104,20 +104,20 @@ impl<'c> ChaperoneSetupManager<'c> {
                 .as_mut()
                 .GetLiveCollisionBoundsInfo(quads.as_mut_ptr(), &mut num_quads)
         };
-        if !success {
-            return vec![];
+        if success {
+            unsafe { quads.set_len(num_quads as usize) };
         }
         quads
     }
 
     pub fn get_working_collision_bounds_info(&mut self) -> Vec<HmdQuad_t> {
         let mut num_quads = 0u32;
-        let success = unsafe {
+        unsafe {
             self.inner
                 .as_mut()
                 .GetWorkingCollisionBoundsInfo(ptr::null_mut(), &mut num_quads)
         };
-        if !success {
+        if num_quads == 0 {
             return vec![];
         }
         let mut quads: Vec<HmdQuad_t> = Vec::with_capacity(num_quads as usize);
@@ -126,8 +126,8 @@ impl<'c> ChaperoneSetupManager<'c> {
                 .as_mut()
                 .GetWorkingCollisionBoundsInfo(quads.as_mut_ptr(), &mut num_quads)
         };
-        if !success {
-            return vec![];
+        if success {
+            unsafe { quads.set_len(num_quads as usize) };
         }
         quads
     }

--- a/src/chaperone_setup.rs
+++ b/src/chaperone_setup.rs
@@ -1,4 +1,4 @@
-use sys::{HmdMatrix34_t, HmdQuad_t};
+use sys::{HmdMatrix34_t, HmdQuad_t, HmdVector2_t};
 
 use crate::{sys, Context};
 
@@ -170,6 +170,14 @@ impl<'c> ChaperoneSetupManager<'c> {
             Some(unsafe { rect.assume_init() })
         } else {
             None
+        }
+    }
+
+    pub fn set_working_perimeter(&mut self, points: &mut [HmdVector2_t]) {
+        unsafe {
+            self.inner
+                .as_mut()
+                .SetWorkingPerimeter(points.as_mut_ptr(), points.len() as _)
         }
     }
 

--- a/src/chaperone_setup.rs
+++ b/src/chaperone_setup.rs
@@ -1,7 +1,10 @@
+use sys::HmdMatrix34_t;
+
 use crate::{sys, Context};
 
 use std::ffi::CString;
 use std::marker::PhantomData;
+use std::mem::MaybeUninit;
 use std::pin::Pin;
 use std::ptr::null_mut;
 
@@ -39,5 +42,31 @@ impl<'c> ChaperoneSetupManager<'c> {
         } else {
             None
         }
+    }
+
+    pub fn get_working_standing_zero_pose_to_raw_tracking_pose(&mut self) -> Option<HmdMatrix34_t> {
+        let mut pose = MaybeUninit::uninit();
+        let success = unsafe {
+            self.inner
+                .as_mut()
+                .GetWorkingStandingZeroPoseToRawTrackingPose(pose.as_mut_ptr())
+        };
+        if success {
+            Some(unsafe { pose.assume_init() })
+        } else {
+            None
+        }
+    }
+
+    pub fn set_working_standing_zero_pose_to_raw_tracking_pose(&mut self, mat: &HmdMatrix34_t) {
+        unsafe {
+            self.inner
+                .as_mut()
+                .SetWorkingStandingZeroPoseToRawTrackingPose(mat)
+        }
+    }
+
+    pub fn commit_working_copy(&mut self, config: sys::EChaperoneConfigFile) -> bool {
+        unsafe { self.inner.as_mut().CommitWorkingCopy(config) }
     }
 }

--- a/src/chaperone_setup.rs
+++ b/src/chaperone_setup.rs
@@ -58,6 +58,20 @@ impl<'c> ChaperoneSetupManager<'c> {
         }
     }
 
+    pub fn get_working_seated_zero_pose_to_raw_tracking_pose(&mut self) -> Option<HmdMatrix34_t> {
+        let mut pose = MaybeUninit::uninit();
+        let success = unsafe {
+            self.inner
+                .as_mut()
+                .GetWorkingSeatedZeroPoseToRawTrackingPose(pose.as_mut_ptr())
+        };
+        if success {
+            Some(unsafe { pose.assume_init() })
+        } else {
+            None
+        }
+    }
+
     pub fn set_working_standing_zero_pose_to_raw_tracking_pose(&mut self, mat: &HmdMatrix34_t) {
         unsafe {
             self.inner
@@ -66,7 +80,19 @@ impl<'c> ChaperoneSetupManager<'c> {
         }
     }
 
+    pub fn set_working_seated_zero_pose_to_raw_tracking_pose(&mut self, mat: &HmdMatrix34_t) {
+        unsafe {
+            self.inner
+                .as_mut()
+                .SetWorkingSeatedZeroPoseToRawTrackingPose(mat)
+        }
+    }
+
     pub fn commit_working_copy(&mut self, config: sys::EChaperoneConfigFile) -> bool {
         unsafe { self.inner.as_mut().CommitWorkingCopy(config) }
+    }
+
+    pub fn revert_working_copy(&mut self) {
+        unsafe { self.inner.as_mut().RevertWorkingCopy() }
     }
 }

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -4,8 +4,6 @@ use std::pin::Pin;
 
 use crate::{errors::EVRCompositorError, sys, Context};
 
-pub struct VkPhysicalDevice(u64);
-
 pub struct CompositorManager<'c> {
     ctx: PhantomData<&'c Context>,
     inner: Pin<&'c mut sys::IVRCompositor>,
@@ -73,12 +71,9 @@ impl<'c> CompositorManager<'c> {
         s.split(' ').map(|s| s.to_owned()).collect()
     }
 
-    pub fn get_vulkan_device_extensions_required(
-        &mut self,
-        device: &VkPhysicalDevice,
-    ) -> Vec<String> {
+    pub fn get_vulkan_device_extensions_required(&mut self, device: u64) -> Vec<String> {
         let mut buf = [0i8; 1024];
-        let mut handle = device.0;
+        let mut handle = device;
         unsafe {
             let len = self.inner.as_mut().GetVulkanDeviceExtensionsRequired(
                 (&mut handle) as *mut u64 as *mut _,

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -73,10 +73,9 @@ impl<'c> CompositorManager<'c> {
 
     pub fn get_vulkan_device_extensions_required(&mut self, device: u64) -> Vec<String> {
         let mut buf = [0i8; 1024];
-        let mut handle = device;
         unsafe {
             let len = self.inner.as_mut().GetVulkanDeviceExtensionsRequired(
-                (&mut handle) as *mut u64 as *mut _,
+                device as usize as _,
                 buf.as_mut_ptr(),
                 buf.len() as u32,
             );

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -1,0 +1,96 @@
+use std::ffi::CStr;
+use std::marker::PhantomData;
+use std::pin::Pin;
+
+use crate::{errors::EVRCompositorError, sys, Context};
+
+pub struct VkPhysicalDevice(u64);
+
+pub struct CompositorManager<'c> {
+    ctx: PhantomData<&'c Context>,
+    inner: Pin<&'c mut sys::IVRCompositor>,
+}
+
+type Result<T> = std::result::Result<T, EVRCompositorError>;
+
+impl<'c> CompositorManager<'c> {
+    pub(super) fn new(_ctx: &'c Context) -> Self {
+        let inner = unsafe { Pin::new_unchecked(sys::VRCompositor().as_mut::<'c>().unwrap()) };
+        Self {
+            ctx: Default::default(),
+            inner,
+        }
+    }
+
+    pub fn get_last_poses(
+        &mut self,
+        poses: &mut [sys::TrackedDevicePose_t],
+        game_pose: &mut [sys::TrackedDevicePose_t],
+    ) -> Result<()> {
+        let err = unsafe {
+            self.inner.as_mut().GetLastPoses(
+                poses.as_mut_ptr(),
+                poses.len() as u32,
+                game_pose.as_mut_ptr(),
+                game_pose.len() as u32,
+            )
+        };
+        EVRCompositorError::new(err)
+    }
+
+    pub fn get_tracking_space(&mut self) -> sys::ETrackingUniverseOrigin {
+        unsafe { self.inner.as_mut().GetTrackingSpace() }
+    }
+
+    pub fn get_frame_time_remaining(&mut self) -> f32 {
+        unsafe { self.inner.as_mut().GetFrameTimeRemaining() }
+    }
+
+    pub fn get_current_scene_focus_process(&mut self) -> u32 {
+        unsafe { self.inner.as_mut().GetCurrentSceneFocusProcess() }
+    }
+
+    pub fn get_last_frame_renderer(&mut self) -> u32 {
+        unsafe { self.inner.as_mut().GetLastFrameRenderer() }
+    }
+
+    pub fn is_current_scene_focus_app_loading(&mut self) -> bool {
+        unsafe { self.inner.as_mut().IsCurrentSceneFocusAppLoading() }
+    }
+
+    pub fn get_vulkan_instance_extensions_required(&mut self) -> Vec<String> {
+        let mut buf = [0i8; 1024];
+        let len = unsafe {
+            self.inner
+                .as_mut()
+                .GetVulkanInstanceExtensionsRequired(buf.as_mut_ptr(), buf.len() as u32)
+        };
+        if len == 0 {
+            return vec![];
+        }
+        let cstr = unsafe { CStr::from_ptr(buf.as_ptr()) };
+        let s = cstr.to_str().unwrap();
+        s.split(' ').map(|s| s.to_owned()).collect()
+    }
+
+    pub fn get_vulkan_device_extensions_required(
+        &mut self,
+        device: &VkPhysicalDevice,
+    ) -> Vec<String> {
+        let mut buf = [0i8; 1024];
+        let mut handle = device.0;
+        unsafe {
+            let len = self.inner.as_mut().GetVulkanDeviceExtensionsRequired(
+                (&mut handle) as *mut u64 as *mut _,
+                buf.as_mut_ptr(),
+                buf.len() as u32,
+            );
+            if len == 0 {
+                return vec![];
+            }
+        }
+        let cstr = unsafe { CStr::from_ptr(buf.as_ptr()) };
+        let s = cstr.to_str().unwrap();
+        s.split(' ').map(|s| s.to_owned()).collect()
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -45,7 +45,33 @@ impl EVROverlayError {
     }
 
     pub fn description(&self) -> &'static str {
-        "todo"
+        use sys::EVROverlayError::*;
+        match self.0 {
+            VROverlayError_None => "None",
+            VROverlayError_UnknownOverlay => "UnknownOverlay",
+            VROverlayError_InvalidHandle => "InvalidHandle",
+            VROverlayError_PermissionDenied => "PermissionDenied",
+            VROverlayError_OverlayLimitExceeded => "OverlayLimitExceeded",
+            VROverlayError_WrongVisibilityType => "WrongVisibilityType",
+            VROverlayError_KeyTooLong => "KeyTooLong",
+            VROverlayError_NameTooLong => "NameTooLong",
+            VROverlayError_KeyInUse => "KeyInUse",
+            VROverlayError_WrongTransformType => "WrongTransformType",
+            VROverlayError_InvalidTrackedDevice => "InvalidTrackedDevice",
+            VROverlayError_InvalidParameter => "InvalidParameter",
+            VROverlayError_ThumbnailCantBeDestroyed => "ThumbnailCantBeDestroyed",
+            VROverlayError_ArrayTooSmall => "ArrayTooSmall",
+            VROverlayError_RequestFailed => "RequestFailed",
+            VROverlayError_InvalidTexture => "InvalidTexture",
+            VROverlayError_UnableToLoadFile => "UnableToLoadFile",
+            VROverlayError_KeyboardAlreadyInUse => "KeyboardAlreadyInUse",
+            VROverlayError_NoNeighbor => "NoNeighbor",
+            VROverlayError_TooManyMaskPrimitives => "TooManyMaskPrimitives",
+            VROverlayError_BadMaskPrimitive => "BadMaskPrimitive",
+            VROverlayError_TextureAlreadyLocked => "TextureAlreadyLocked",
+            VROverlayError_TextureNotLocked => "TextureNotLocked",
+            VROverlayError_TextureLockCapacityReached => "TextureLockCapacityReached",
+        }
     }
 
     pub fn inner(&self) -> sys::EVROverlayError {
@@ -76,7 +102,25 @@ impl ETrackedPropertyError {
     }
 
     pub fn description(&self) -> &'static str {
-        "todo"
+        use sys::ETrackedPropertyError::*;
+        match self.0 {
+            TrackedProp_Success => "Success",
+            TrackedProp_WrongDataType => "WrongDataType",
+            TrackedProp_WrongDeviceClass => "WrongDeviceClass",
+            TrackedProp_BufferTooSmall => "BufferTooSmall",
+            TrackedProp_UnknownProperty => "UnknownProperty",
+            TrackedProp_InvalidDevice => "InvalidDevice",
+            TrackedProp_CouldNotContactServer => "CouldNotContactServer",
+            TrackedProp_ValueNotProvidedByDevice => "ValueNotProvidedByDevice",
+            TrackedProp_StringExceedsMaximumLength => "StringExceedsMaximumLength",
+            TrackedProp_NotYetAvailable => "NotYetAvailable",
+            TrackedProp_PermissionDenied => "PermissionDenied",
+            TrackedProp_InvalidOperation => "InvalidOperation",
+            TrackedProp_CannotWriteToWildcards => "CannotWriteToWildcards",
+            TrackedProp_IPCReadFailure => "IPCReadFailure",
+            TrackedProp_OutOfMemory => "OutOfMemory",
+            TrackedProp_InvalidContainer => "InvalidContainer",
+        }
     }
 
     pub fn inner(&self) -> sys::ETrackedPropertyError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -148,6 +148,45 @@ impl Display for EVRInputError {
     }
 }
 
+#[cfg(feature = "ovr_compositor")]
+#[derive(Into, Clone, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct EVRCompositorError(sys::EVRCompositorError);
+
+#[cfg(feature = "ovr_compositor")]
+impl EVRCompositorError {
+    pub fn new(err: sys::EVRCompositorError) -> Result<(), Self> {
+        if err == sys::EVRCompositorError::VRCompositorError_None {
+            Ok(())
+        } else {
+            Err(Self(err))
+        }
+    }
+
+    pub fn description(&self) -> &'static str {
+        use sys::EVRCompositorError::*;
+        match self.0 {
+            VRCompositorError_None => "None",
+            VRCompositorError_RequestFailed => "RequestFailed",
+            VRCompositorError_IncompatibleVersion => "IncompatibleVersion",
+            VRCompositorError_DoNotHaveFocus => "DoNotHaveFocus",
+            VRCompositorError_InvalidTexture => "InvalidTexture",
+            VRCompositorError_IsNotSceneApplication => "IsNotSceneApplication",
+            VRCompositorError_TextureIsOnWrongDevice => "TextureIsOnWrongDevice",
+            VRCompositorError_TextureUsesUnsupportedFormat => "TextureUsesUnsupportedFormat",
+            VRCompositorError_SharedTexturesNotSupported => "SharedTexturesNotSupported",
+            VRCompositorError_IndexOutOfRange => "IndexOutOfRange",
+            VRCompositorError_AlreadySubmitted => "AlreadySubmitted",
+            VRCompositorError_AlreadySet => "AlreadySet",
+            VRCompositorError_InvalidBounds => "InvalidBounds",
+        }
+    }
+
+    pub fn inner(&self) -> sys::EVRCompositorError {
+        self.0.clone()
+    }
+}
+
 #[cfg(feature = "ovr_applications")]
 #[derive(Into, Clone, PartialEq, Eq)]
 #[repr(transparent)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -71,6 +71,7 @@ impl EVROverlayError {
             VROverlayError_TextureAlreadyLocked => "TextureAlreadyLocked",
             VROverlayError_TextureNotLocked => "TextureNotLocked",
             VROverlayError_TextureLockCapacityReached => "TextureLockCapacityReached",
+            VROverlayError_TimedOut => "TimedOut",
         }
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -214,7 +214,7 @@ impl<'c> InputManager<'c> {
     pub fn get_analog_action_data(
         &mut self,
         action: ActionHandle,
-        restrict: InputValueHandle
+        restrict: InputValueHandle,
     ) -> Result<AnalogActionData> {
         let mut data: MaybeUninit<sys::InputAnalogActionData_t> = MaybeUninit::uninit();
         let err = unsafe {
@@ -415,7 +415,7 @@ impl<'c> InputManager<'c> {
         let mut data_vec = vec![];
 
         for i in 0..unsafe { count.assume_init() } {
-            let info = unsafe { data.get_unchecked(i as usize).clone() };
+            let info = unsafe { data.get_unchecked(i as usize) };
             data_vec.push(sys::InputBindingInfo_t {
                 rchDevicePathName: info.rchDevicePathName,
                 rchInputPathName: info.rchInputPathName,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub mod applications;
 #[cfg(feature = "ovr_applications")]
 use self::applications::ApplicationsManager;
 
-mod errors;
+pub mod errors;
 
 pub use self::errors::{EVRInitError, InitError};
 pub use ovr_overlay_sys as sys;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,11 @@ pub mod chaperone_setup;
 #[cfg(feature = "ovr_chaperone_setup")]
 use self::chaperone_setup::ChaperoneSetupManager;
 
+#[cfg(feature = "ovr_compositor")]
+pub mod compositor;
+#[cfg(feature = "ovr_compositor")]
+use self::compositor::CompositorManager;
+
 #[cfg(feature = "ovr_input")]
 pub mod input;
 #[cfg(feature = "ovr_input")]
@@ -108,6 +113,11 @@ impl Context {
     pub fn applications_mngr(&self) -> ApplicationsManager<'_> {
         ApplicationsManager::new(self)
     }
+
+    #[cfg(feature = "ovr_compositor")]
+    pub fn compositor_mngr(&self) -> CompositorManager<'_> {
+        CompositorManager::new(self)
+    }
 }
 
 /// Tints each color channel by multiplying it with the given f32
@@ -176,8 +186,6 @@ impl TrackedDeviceIndex {
     //     self.0 == sys::k_unTrackedDeviceIndexOther
     // }
 }
-
-
 
 #[cfg(test)]
 mod tests {

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -7,8 +7,6 @@ use crate::{sys, ColorTint, Context, TrackedDeviceIndex};
 use derive_more::From;
 use std::marker::PhantomData;
 use std::pin::Pin;
-use sys::glSharedTextureHandle_t;
-use sys::Texture_t;
 use sys::VRVulkanTextureData_t;
 
 pub struct OverlayManager<'c> {

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -40,6 +40,11 @@ impl<'c> OverlayManager<'c> {
         Ok(OverlayHandle(handle))
     }
 
+    pub fn destroy_overlay(&mut self, overlay: OverlayHandle) -> Result<(), EVROverlayError> {
+        let err = unsafe { self.inner.as_mut().DestroyOverlay(overlay.0) };
+        EVROverlayError::new(err)
+    }
+
     pub fn set_visibility(
         &mut self,
         overlay: OverlayHandle,

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -430,6 +430,11 @@ impl<'c> OverlayManager<'c> {
     pub fn is_dashboard_visible(&mut self) -> bool {
         unsafe { self.inner.as_mut().IsDashboardVisible() }
     }
+
+    pub fn wait_frame_sync(&mut self, timeout_ms: u32) -> Result<(), EVROverlayError> {
+        let err = unsafe { self.inner.as_mut().WaitFrameSync(timeout_ms) };
+        EVROverlayError::new(err)
+    }
 }
 unsafe impl Send for OverlayManager<'_> {}
 unsafe impl Sync for OverlayManager<'_> {}

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -231,7 +231,7 @@ impl<'c> OverlayManager<'c> {
             self.inner.as_mut().SetOverlayTexture(
                 overlay.0,
                 &sys::Texture_t {
-                    handle: texture as *mut VRVulkanTextureData_t as _,
+                    handle: texture as *mut VRVulkanTextureData_t as *mut _,
                     eType: sys::ETextureType::TextureType_Vulkan,
                     eColorSpace: sys::EColorSpace::ColorSpace_Auto,
                 },

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -7,6 +7,9 @@ use crate::{sys, ColorTint, Context, TrackedDeviceIndex};
 use derive_more::From;
 use std::marker::PhantomData;
 use std::pin::Pin;
+use sys::glSharedTextureHandle_t;
+use sys::Texture_t;
+use sys::VRVulkanTextureData_t;
 
 pub struct OverlayManager<'c> {
     ctx: PhantomData<&'c Context>,
@@ -199,6 +202,42 @@ impl<'c> OverlayManager<'c> {
             self.inner
                 .as_mut()
                 .SetOverlayFromFile(overlay.0, img_path.as_ptr())
+        };
+        EVROverlayError::new(err)
+    }
+
+    pub fn set_image_opengl(
+        &mut self,
+        overlay: OverlayHandle,
+        texture: u32,
+    ) -> Result<(), EVROverlayError> {
+        let err = unsafe {
+            self.inner.as_mut().SetOverlayTexture(
+                overlay.0,
+                &sys::Texture_t {
+                    handle: texture as usize as _,
+                    eType: sys::ETextureType::TextureType_OpenGL,
+                    eColorSpace: sys::EColorSpace::ColorSpace_Auto,
+                },
+            )
+        };
+        EVROverlayError::new(err)
+    }
+
+    pub fn set_image_vulkan(
+        &mut self,
+        overlay: OverlayHandle,
+        texture: &mut VRVulkanTextureData_t,
+    ) -> Result<(), EVROverlayError> {
+        let err = unsafe {
+            self.inner.as_mut().SetOverlayTexture(
+                overlay.0,
+                &sys::Texture_t {
+                    handle: texture as *mut VRVulkanTextureData_t as _,
+                    eType: sys::ETextureType::TextureType_Vulkan,
+                    eColorSpace: sys::EColorSpace::ColorSpace_Auto,
+                },
+            )
         };
         EVROverlayError::new(err)
     }

--- a/src/system.rs
+++ b/src/system.rs
@@ -220,24 +220,27 @@ impl<'c> SystemManager<'c> {
 
 unsafe impl Send for SystemManager<'_> {}
 unsafe impl Sync for SystemManager<'_> {}
+
+const VREVENT_SIZE: usize = std::mem::size_of::<sys::VREvent_t>();
+
 pub struct VREvent {
     pub event_type: sys::EVREventType,
     pub tracked_device_index: TrackedDeviceIndex,
     pub event_age_seconds: f32,
-    pub data: [u8; 52],
+    pub data: [u8; VREVENT_SIZE - 12],
 }
 
 impl VREvent {
     fn parse(event: sys::VREvent_t) -> VREvent {
-        let bytes: [u8; 64] = unsafe {
+        let bytes: [u8; VREVENT_SIZE] = unsafe {
             *std::slice::from_raw_parts(
                 &event as *const sys::VREvent_t as *const u8,
                 std::mem::size_of::<sys::VREvent_t>(),
             )
             .as_array()
         };
-        let data = &bytes[12..64];
-        let mut data_slice: [u8; 52] = [0; 52];
+        let data = &bytes[12..VREVENT_SIZE];
+        let mut data_slice: [u8; VREVENT_SIZE - 12] = [0; VREVENT_SIZE - 12];
         data_slice.copy_from_slice(data);
         unsafe {
             VREvent {

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,6 +1,6 @@
 use byteorder::ByteOrder;
 use slice_of_array::SliceArrayExt;
-use sys::ETrackingUniverseOrigin;
+use sys::{ETrackingUniverseOrigin, HmdMatrix34_t};
 
 use crate::errors::ETrackedPropertyError;
 use crate::{sys, Context, TrackedDeviceIndex};
@@ -194,6 +194,16 @@ impl<'c> SystemManager<'c> {
             )
         };
         poses
+    }
+
+    pub fn get_raw_zero_pose_to_standing_absolute_tracking_pose<'ret, 'manager: 'ret>(
+        &'manager mut self,
+    ) -> HmdMatrix34_t {
+        unsafe {
+            self.inner
+                .as_mut()
+                .GetRawZeroPoseToStandingAbsoluteTrackingPose()
+        }
     }
 
     pub fn get_time_since_last_vsync<'ret, 'manager: 'ret>(

--- a/src/system.rs
+++ b/src/system.rs
@@ -189,6 +189,18 @@ impl<'c> SystemManager<'c> {
         poses
     }
 
+    pub fn get_time_since_last_vsync<'ret, 'manager: 'ret>(
+        &'manager mut self,
+        seconds_since_last_vsync: &mut f32,
+        frame_counter: &mut u64,
+    ) -> bool {
+        unsafe {
+            self.inner
+                .as_mut()
+                .GetTimeSinceLastVsync(seconds_since_last_vsync, frame_counter)
+        }
+    }
+
     pub fn poll_next_event<'ret, 'manager: 'ret>(&'manager mut self) -> Option<VREvent> {
         let mut event = std::mem::MaybeUninit::uninit();
         let res = unsafe {

--- a/src/system.rs
+++ b/src/system.rs
@@ -171,22 +171,11 @@ impl<'c> SystemManager<'c> {
         unsafe { self.inner.as_mut().GetTrackedDeviceClass(index.0) }
     }
 
-    pub fn get_sorted_tracked_device_indices_of_class<'ret, 'manager: 'ret>(
+    pub fn is_tracked_device_connected<'ret, 'manager: 'ret>(
         &'manager mut self,
-        class: sys::ETrackedDeviceClass,
-        relative_to_index: TrackedDeviceIndex,
-    ) -> Vec<TrackedDeviceIndex> {
-        let mut device_ids = Vec::with_capacity(64);
-        unsafe {
-            let num_ids = self.inner.as_mut().GetSortedTrackedDeviceIndicesOfClass(
-                class,
-                device_ids.as_mut_ptr() as *mut _,
-                device_ids.len() as u32,
-                relative_to_index.0,
-            );
-            device_ids.set_len(num_ids as usize);
-        }
-        device_ids
+        index: TrackedDeviceIndex,
+    ) -> bool {
+        unsafe { self.inner.as_mut().IsTrackedDeviceConnected(index.0) }
     }
 
     pub fn get_device_to_absolute_tracking_pose<'ret, 'manager: 'ret>(

--- a/src/system.rs
+++ b/src/system.rs
@@ -171,6 +171,24 @@ impl<'c> SystemManager<'c> {
         unsafe { self.inner.as_mut().GetTrackedDeviceClass(index.0) }
     }
 
+    pub fn get_sorted_tracked_device_indices_of_class<'ret, 'manager: 'ret>(
+        &'manager mut self,
+        class: sys::ETrackedDeviceClass,
+        relative_to_index: TrackedDeviceIndex,
+    ) -> Vec<TrackedDeviceIndex> {
+        let mut device_ids = Vec::with_capacity(64);
+        unsafe {
+            let num_ids = self.inner.as_mut().GetSortedTrackedDeviceIndicesOfClass(
+                class,
+                device_ids.as_mut_ptr() as *mut _,
+                device_ids.len() as u32,
+                relative_to_index.0,
+            );
+            device_ids.set_len(num_ids as usize);
+        }
+        device_ids
+    }
+
     pub fn get_device_to_absolute_tracking_pose<'ret, 'manager: 'ret>(
         &'manager mut self,
         origin: ETrackingUniverseOrigin,

--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -47,6 +47,7 @@ include_cpp! {
     generate_pod!("vr::ETrackingUniverseOrigin")
     generate!("vr::HmdMatrix34_t")
     generate_pod!("vr::HmdVector3_t")
+    generate_pod!("vr::HmdVector2_t")
     generate_pod!("vr::HmdQuaternion_t")
     generate_pod!("vr::HmdQuad_t")
 

--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -69,6 +69,11 @@ include_cpp! {
     generate!("vr::IVRApplications")
     generate!("vr::VRApplications")
     generate_pod!("vr::EVRApplicationError")
+
+    //compositor
+    generate!("vr::IVRCompositor")
+    generate!("vr::VRCompositor")
+    generate_pod!("vr::EVRCompositorError")
 }
 
 //pub use ffi::vr::*;

--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -71,6 +71,7 @@ include_cpp! {
     generate_pod!("vr::EVRApplicationError")
 
     //compositor
+    generate!("vr::VRVulkanTextureData_t")
     generate!("vr::IVRCompositor")
     generate!("vr::VRCompositor")
     generate_pod!("vr::EVRCompositorError")

--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -48,6 +48,7 @@ include_cpp! {
     generate!("vr::HmdMatrix34_t")
     generate_pod!("vr::HmdVector3_t")
     generate_pod!("vr::HmdQuaternion_t")
+    generate_pod!("vr::HmdQuad_t")
 
     generate_pod!("vr::VRTextureBounds_t")
 

--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -35,6 +35,8 @@ include_cpp! {
     generate!("vr::VROverlay")
     generate_pod!("vr::EVROverlayError")
     generate_pod!("vr::VROverlayHandle_t")
+    generate_pod!("vr::VRVulkanTextureData_t")
+    generate_pod!("vr::Texture_t")
 
     generate!("vr::IVRChaperoneSetup")
     generate!("vr::VRChaperoneSetup")


### PR DESCRIPTION
## Add `ovr_compositor`
- `get_last_poses`
- `get_tracking_space`
- `get_frame_time_remaining`
- `get_current_scene_focus_process`
- `get_last_frame_renderer`
- `is_current_scene_focus_app_loading`

Vulkan specific - these are required to upload Vulkan images as overlay textures.
I made these use primitive types to avoid having to pull in libraries such as Ash.
- `get_vulkan_instance_extensions_required`
- `get_vulkan_device_extensions_required`

## Additions to `ovr_overlay`
- `set_image_opengl`
- `set_image_vulkan`

## Changes to `ovr_input`
- `get_analog_action_data` remove unnecessary clone

## Changes to `ovr_system`
- Added `get_time_since_last_vsync`
- `VREvent` fix - I had issues with specific events not being able to fit in the `[u8; 52]` array, and so now it's using an array size determined from `mem::size_of::<sys::VREvent_t>()`
